### PR TITLE
1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Add Solar, Lunar classes
 - Use bool instead of int for lunarLeap
 - Set default timezone to 7 (GMT+7)
+- Fix a bug in jdToDate function that sometimes leads to wrong calculation
 
 ## 1.0.2
 - Refactor with minor changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.1.0
-- Add Solar, Lunar classes 
+- Add Solar, Lunar classes
+- Use bool instead of int for lunarLeap
+- Set default timezone to 7 (GMT+7)
 
 ## 1.0.2
 - Refactor with minor changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+- Add Solar, Lunar classes 
+
 ## 1.0.2
 - Refactor with minor changes
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Thanks to him for inspiring me to create this package in Dart.
 
 ## Usage
 
+- From version 1.1.0, the package supports Classes instead of Lists for easier access. `Lunar` and `Solar` provide methods to interact with each other, or converted to DateTime object.
+```dart
+  final lunar = Lunar(createdFromSolar: true, date: DateTime(1998, 6, 18));
+  final solar = Solar(DateTime(1998, 6, 18));
+  final convertedSolarFromLunar = lunar.getSolar();
+  
+  // solar == convertedSolarFromLunar -> true
+```
+
 - The `convertSolar2Lunar` function returns a List by order: [lunarDay, lunarMonth, lunarYear, leap], where `leap` indicates whether the lunarMonth is a leap or not.
 ```dart
 int dd = 23;

--- a/example/vnlunar_example.dart
+++ b/example/vnlunar_example.dart
@@ -1,1 +1,9 @@
-void main() {}
+import 'package:vnlunar/vnlunar.dart';
+
+void main() {
+  final lunar = Lunar(createdFromSolar: true, date: DateTime(1998, 6, 18));
+  final solar = Solar(DateTime(1998, 6, 18));
+  final convertedSolarFromLunar = lunar.getSolar();
+
+  print(solar == convertedSolarFromLunar); // true
+}

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,0 +1,5 @@
+const int vnTimezone = 7;
+const int daysInYear = 365;
+const int yearIndex = 2;
+const int monthIndex = 1;
+const int dayIndex = 0;

--- a/lib/src/lunar.dart
+++ b/lib/src/lunar.dart
@@ -1,11 +1,11 @@
 // ignore_for_file: unnecessary_overrides
 
 import 'package:vnlunar/src/constants.dart';
-import 'package:vnlunar/src/vnlunar_base.dart';
 
 import 'solar.dart';
+import 'vnlunar_base.dart';
 
-class Lunar implements Comparable<Lunar> {
+class Lunar extends VNLunar implements Comparable<Lunar> {
   late final int _year;
   int get year => _year;
 
@@ -24,8 +24,8 @@ class Lunar implements Comparable<Lunar> {
   late final int _second;
   int get second => _second;
 
-  late final bool _leapMonth;
-  bool get leapMonth => _leapMonth;
+  late final bool? _leapMonth;
+  bool? get leapMonth => _leapMonth;
 
   /// Create an instance of [Lunar] from [date]. If [date] is null,
   /// automatically constructs a [Lunar] with current date and time
@@ -45,9 +45,9 @@ class Lunar implements Comparable<Lunar> {
           createdFromSolar: true,
         );
 
-  /// Convert to Solar.
+  /// Convert to Solar. leapMonth = false if not specified.
   Solar getSolar() {
-    final solar = convertLunar2Solar(_day, _month, _year, _leapMonth);
+    final solar = convertLunar2Solar(_day, _month, _year, _leapMonth ?? false);
     return Solar(DateTime(
       solar[yearIndex],
       solar[monthIndex],
@@ -91,10 +91,14 @@ class Lunar implements Comparable<Lunar> {
         other.day == _day &&
         other.hour == _hour &&
         other.minute == _minute &&
-        other.second == _second &&
-        other.leapMonth == _leapMonth;
+        other.second == _second;
   }
 
   @override
   int get hashCode => super.hashCode;
+
+  @override
+  DateTime toDateTime() {
+    return DateTime(_year, _month, _day, _hour, _minute, _second);
+  }
 }

--- a/lib/src/lunar.dart
+++ b/lib/src/lunar.dart
@@ -1,0 +1,3 @@
+class Lunar {
+  Lunar();
+}

--- a/lib/src/lunar.dart
+++ b/lib/src/lunar.dart
@@ -1,3 +1,81 @@
-class Lunar {
-  Lunar();
+// ignore_for_file: unnecessary_overrides
+
+import 'package:vnlunar/src/constants.dart';
+import 'package:vnlunar/src/vnlunar_base.dart';
+
+import 'solar.dart';
+
+class Lunar implements Comparable<Lunar> {
+  late final int _year;
+  int get year => _year;
+
+  late final int _month;
+  int get month => _month;
+
+  late final int _day;
+  int get day => _day;
+
+  late final int _hour;
+  int get hour => _hour;
+
+  late final int _minute;
+  int get minute => _minute;
+
+  late final int _second;
+  int get second => _second;
+
+  late final bool _leapMonth;
+  bool get leapMonth => _leapMonth;
+
+  /// Create an instance of [Lunar] from [dateTime]. If [dateTime] is null,
+  /// automatically constructs a [Lunar] with current date and time
+  /// in the local time zone.
+  Lunar([DateTime? dateTime])
+      : this._fromDate(dateTime ?? DateTime.now().toLocal());
+
+  /// Create an instance of [Lunar] from [Solar].
+  Lunar.fromSolar(Solar solar) : this(solar.toDateTime());
+
+  /// Convert to Solar.
+  Solar getSolar() {
+    final solar = convertLunar2Solar(_day, _month, _year, _leapMonth);
+    return Solar(DateTime(
+      solar[yearIndex],
+      solar[monthIndex],
+      solar[dayIndex],
+    ));
+  }
+
+  Lunar._fromDate(DateTime dateTime) {
+    final lunar =
+        convertSolar2Lunar(dateTime.day, dateTime.month, dateTime.year);
+    _year = lunar[yearIndex];
+    _month = lunar[monthIndex];
+    _day = lunar[dayIndex];
+    _leapMonth = (lunar.last == 1);
+    _hour = dateTime.hour;
+    _minute = dateTime.minute;
+    _second = dateTime.second;
+  }
+
+  @override
+  int compareTo(Lunar other) {
+    if (this == other) return 0;
+    return getSolar().compareTo(other.getSolar());
+  }
+
+  @override
+  bool operator ==(other) {
+    return other is Lunar &&
+        other.year == _year &&
+        other.month == _month &&
+        other.day == _day &&
+        other.hour == _hour &&
+        other.minute == _minute &&
+        other.second == _second &&
+        other.leapMonth == _leapMonth;
+  }
+
+  @override
+  int get hashCode => super.hashCode;
 }

--- a/lib/src/lunar.dart
+++ b/lib/src/lunar.dart
@@ -27,14 +27,23 @@ class Lunar implements Comparable<Lunar> {
   late final bool _leapMonth;
   bool get leapMonth => _leapMonth;
 
-  /// Create an instance of [Lunar] from [dateTime]. If [dateTime] is null,
+  /// Create an instance of [Lunar] from [date]. If [date] is null,
   /// automatically constructs a [Lunar] with current date and time
   /// in the local time zone.
-  Lunar([DateTime? dateTime])
-      : this._fromDate(dateTime ?? DateTime.now().toLocal());
+  Lunar({
+    DateTime? date,
+    required bool createdFromSolar,
+  }) : this._fromDate(
+          date ?? DateTime.now().toLocal(),
+          createdFromSolar,
+        );
 
   /// Create an instance of [Lunar] from [Solar].
-  Lunar.fromSolar(Solar solar) : this(solar.toDateTime());
+  Lunar.fromSolar(Solar solar)
+      : this(
+          date: solar.toDateTime(),
+          createdFromSolar: true,
+        );
 
   /// Convert to Solar.
   Solar getSolar() {
@@ -46,7 +55,17 @@ class Lunar implements Comparable<Lunar> {
     ));
   }
 
-  Lunar._fromDate(DateTime dateTime) {
+  Lunar._fromDate(DateTime dateTime, bool createdFromSolar) {
+    if (!createdFromSolar) {
+      _year = dateTime.year;
+      _month = dateTime.month;
+      _day = dateTime.day;
+      _hour = dateTime.hour;
+      _minute = dateTime.minute;
+      _second = dateTime.second;
+      return;
+    }
+
     final lunar =
         convertSolar2Lunar(dateTime.day, dateTime.month, dateTime.year);
     _year = lunar[yearIndex];

--- a/lib/src/solar.dart
+++ b/lib/src/solar.dart
@@ -1,10 +1,11 @@
 // ignore_for_file: unnecessary_overrides
 
 import 'lunar.dart';
+import 'vnlunar_base.dart';
 
 /// An instant in time, similar to [DateTime] object, having functions
 /// that helps interacting with [Lunar] much more easier.
-class Solar implements Comparable<Solar> {
+class Solar extends VNLunar implements Comparable<Solar> {
   late final int _year;
   int get year => _year;
 
@@ -38,6 +39,7 @@ class Solar implements Comparable<Solar> {
     _second = dateTime.second;
   }
 
+  @override
   DateTime toDateTime() {
     return DateTime(
       _year,

--- a/lib/src/solar.dart
+++ b/lib/src/solar.dart
@@ -1,0 +1,71 @@
+// ignore_for_file: unnecessary_overrides
+
+import 'lunar.dart';
+
+/// An instant in time, similar to [DateTime] object, having functions
+/// that helps interacting with [Lunar] much more easier.
+class Solar implements Comparable<Solar> {
+  late final int _year;
+  int get year => _year;
+
+  late final int _month;
+  int get month => _month;
+
+  late final int _day;
+  int get day => _day;
+
+  late final int _hour;
+  int get hour => _hour;
+
+  late final int _minute;
+  int get minute => _minute;
+
+  late final int _second;
+  int get second => _second;
+
+  /// Create an instance of [Solar] from [dateTime]. If [dateTime] is null,
+  /// automatically constructs a [Solar] with current date and time
+  /// in the local time zone.
+  Solar(DateTime? dateTime)
+      : this._fromDate(dateTime ?? DateTime.now().toLocal());
+
+  Solar._fromDate(DateTime dateTime) {
+    _year = dateTime.year;
+    _month = dateTime.month;
+    _day = dateTime.day;
+    _hour = dateTime.hour;
+    _minute = dateTime.minute;
+    _second = dateTime.second;
+  }
+
+  DateTime toDateTime() {
+    return DateTime(
+      _year,
+      _month,
+      _day,
+      _hour,
+      _minute,
+      _second,
+    );
+  }
+
+  @override
+  int compareTo(Solar other) {
+    if (this == other) return 0;
+    return toDateTime().compareTo(other.toDateTime());
+  }
+
+  @override
+  bool operator ==(other) {
+    return other is Solar &&
+        other.year == _year &&
+        other.month == _month &&
+        other.day == _day &&
+        other.hour == _hour &&
+        other.minute == _minute &&
+        other.second == _second;
+  }
+
+  @override
+  int get hashCode => super.hashCode;
+}

--- a/lib/src/solar.dart
+++ b/lib/src/solar.dart
@@ -26,7 +26,7 @@ class Solar implements Comparable<Solar> {
   /// Create an instance of [Solar] from [dateTime]. If [dateTime] is null,
   /// automatically constructs a [Solar] with current date and time
   /// in the local time zone.
-  Solar(DateTime? dateTime)
+  Solar([DateTime? dateTime])
       : this._fromDate(dateTime ?? DateTime.now().toLocal());
 
   Solar._fromDate(DateTime dateTime) {

--- a/lib/src/vnlunar_base.dart
+++ b/lib/src/vnlunar_base.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
-const int _daysInYear = 365;
+import 'constants.dart';
+
 const double _juliusDaysIn1900 = 2415021.076998695;
 const double _newMoonCycle = 29.530588853;
 
@@ -14,7 +15,7 @@ int jdFromDate(int dd, int mm, int yy) {
   m = mm + 12 * a - 3;
   jd = dd +
       ((153 * m + 2) / 5).floor() +
-      _daysInYear * y +
+      daysInYear * y +
       (y / 4).floor() -
       (y / 100).floor() +
       (y / 400).floor() -
@@ -22,7 +23,7 @@ int jdFromDate(int dd, int mm, int yy) {
   if (jd < 2299161) {
     jd = dd +
         ((153 * m + 2) / 5).floor() +
-        _daysInYear * y +
+        daysInYear * y +
         (y / 4).floor() -
         32083;
   }
@@ -124,7 +125,7 @@ double sunLongitude(double jdn) {
 /// The function returns a number between 0 and 11.
 /// From the day after March equinox and the 1st major term after March equinox, 0 is returned.
 /// After that, return 1, 2, 3 ...
-int getSunLongitude(int dayNumber, int timeZone) {
+int getSunLongitude(int dayNumber, [int timeZone = vnTimezone]) {
   return (sunLongitude(dayNumber - 0.5 - timeZone / 24) / pi * 6).floor();
 }
 
@@ -135,7 +136,7 @@ int getNewMoonDay(int k, int timeZone) {
 }
 
 /// Find the day that starts the luner month 11 of the given year for the given time zone.
-int getLunarMonth11(int yy, int timeZone) {
+int getLunarMonth11(int yy, [int timeZone = vnTimezone]) {
   int k, nm, sunLong;
   double off;
   off = jdFromDate(31, 12, yy) - 2415021;
@@ -149,7 +150,7 @@ int getLunarMonth11(int yy, int timeZone) {
 }
 
 /// Find the index of the leap month after the month starting on the day a11.
-int getLeapMonthOffset(int a11, int timeZone) {
+int getLeapMonthOffset(int a11, [int timeZone = vnTimezone]) {
   int k, last, arc, i;
   k = ((a11 - _juliusDaysIn1900) / _newMoonCycle + 0.5).floor();
   last = 0;
@@ -164,7 +165,12 @@ int getLeapMonthOffset(int a11, int timeZone) {
 }
 
 /// Convert solar date dd/mm/yyyy to the corresponding lunar date.
-List<int> convertSolar2Lunar(int dd, int mm, int yy, int timeZone) {
+List<int> convertSolar2Lunar(
+  int dd,
+  int mm,
+  int yy, [
+  int timeZone = vnTimezone,
+]) {
   int k,
       dayNumber,
       monthStart,
@@ -193,7 +199,7 @@ List<int> convertSolar2Lunar(int dd, int mm, int yy, int timeZone) {
   int diff = (monthStart - a11) ~/ 29;
   lunarLeap = 0;
   lunarMonth = diff + 11;
-  if (b11 - a11 > _daysInYear) {
+  if (b11 - a11 > daysInYear) {
     int leapMonthDiff = getLeapMonthOffset(a11, timeZone);
     if (diff >= leapMonthDiff) {
       lunarMonth = diff + 10;
@@ -213,7 +219,12 @@ List<int> convertSolar2Lunar(int dd, int mm, int yy, int timeZone) {
 
 /// Convert lunar date to the corresponding solar date.
 List<int> convertLunar2Solar(
-    int lunarDay, int lunarMonth, int lunarYear, int lunarLeap, int timeZone) {
+  int lunarDay,
+  int lunarMonth,
+  int lunarYear,
+  bool lunarLeap, [
+  int timeZone = vnTimezone,
+]) {
   int k, a11, b11, off, leapOff, leapMonth, monthStart;
   if (lunarMonth < 11) {
     a11 = getLunarMonth11(lunarYear - 1, timeZone);
@@ -227,15 +238,15 @@ List<int> convertLunar2Solar(
   if (off < 0) {
     off += 12;
   }
-  if (b11 - a11 > _daysInYear) {
+  if (b11 - a11 > daysInYear) {
     leapOff = getLeapMonthOffset(a11, timeZone);
     leapMonth = leapOff - 2;
     if (leapMonth < 0) {
       leapMonth += 12;
     }
-    if (lunarLeap != 0 && lunarMonth != leapMonth) {
+    if (lunarLeap && lunarMonth != leapMonth) {
       return [0, 0, 0];
-    } else if (lunarLeap != 0 || off >= leapOff) {
+    } else if (lunarLeap || off >= leapOff) {
       off += 1;
     }
   }

--- a/lib/src/vnlunar_base.dart
+++ b/lib/src/vnlunar_base.dart
@@ -36,7 +36,7 @@ List<int> jdToDate(int jd) {
   if (jd > 2299160) {
     a = jd + 32044;
     b = ((4 * a + 3) / 146097).floor();
-    c = (a - (b * 146097) / 4).floor();
+    c = a - ((b * 146097) / 4).floor();
   } else {
     b = 0;
     c = jd + 32082;
@@ -244,9 +244,9 @@ List<int> convertLunar2Solar(
     if (leapMonth < 0) {
       leapMonth += 12;
     }
-    if (lunarLeap && lunarMonth != leapMonth) {
+    if (lunarLeap && (lunarMonth != leapMonth)) {
       return [0, 0, 0];
-    } else if (lunarLeap || off >= leapOff) {
+    } else if (lunarLeap || (off >= leapOff)) {
       off += 1;
     }
   }

--- a/lib/src/vnlunar_base.dart
+++ b/lib/src/vnlunar_base.dart
@@ -5,6 +5,13 @@ import 'constants.dart';
 const double _juliusDaysIn1900 = 2415021.076998695;
 const double _newMoonCycle = 29.530588853;
 
+abstract class VNLunar {
+  /// Returns DateTime format. If the current object is using Lunar system,
+  /// returns its properties with DateTime format. [Lunar] can use `toSolar` then
+  /// `toDateTime`, which is the same.
+  DateTime toDateTime();
+}
+
 /// Compute the (integral) Julian day number of day dd/mm/yyyy, i.e., the number
 /// of days between 1/1/4713 BC (Julian calendar) and dd/mm/yyyy.
 /// Formula from http://www.tondering.dk/claus/calendar.html

--- a/lib/vnlunar.dart
+++ b/lib/vnlunar.dart
@@ -1,1 +1,3 @@
+export 'src/lunar.dart';
+export 'src/solar.dart';
 export 'src/vnlunar_base.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vnlunar
 description: A package that helps convert Vietnamese Lunar Calendar to Solar and vice versa.
-version: 1.0.2
+version: 1.1.0
 repository: https://github.com/nguyen703/vnlunar
 
 environment:

--- a/test/vnlunar_test.dart
+++ b/test/vnlunar_test.dart
@@ -1,5 +1,5 @@
 import 'package:test/test.dart';
-import 'package:vnlunar/src/vnlunar_base.dart';
+import 'package:vnlunar/vnlunar.dart';
 
 void main() {
   test('get Julian from a date', () {
@@ -93,5 +93,67 @@ void main() {
 
     // Assert
     expect(solar, [23, 3, 2023]);
+  });
+
+  test('compare Solar with lunar.getSolar', () {
+    // Arrange
+    DateTime exampleDate = DateTime(1999, 6, 18);
+    Lunar lunar = Lunar(createdFromSolar: true, date: exampleDate);
+    Solar solar = Solar(exampleDate);
+    Solar convertedSolarFromLunar = lunar.getSolar();
+
+    // Act
+    bool compare = convertedSolarFromLunar == solar;
+
+    // Assert
+    expect(compare, true);
+  });
+
+  test('compare Solar with lunar.getSolar', () {
+    // Arrange
+    DateTime exampleDate = DateTime(1999, 6, 19);
+    Lunar lunar = Lunar(createdFromSolar: true, date: exampleDate);
+    Solar solar = Solar(DateTime(1999, 6, 18));
+    Solar convertedSolarFromLunar = lunar.getSolar();
+
+    // Act
+    bool compare = convertedSolarFromLunar == solar;
+
+    // Assert
+    expect(compare, false);
+  });
+
+  test('initialize Lunar with createdFromSolar = false', () {
+    // Arrange
+    DateTime exampleDate = DateTime(1999, 6, 18);
+
+    // Act
+    Lunar lunar = Lunar(createdFromSolar: false, date: exampleDate);
+
+    // Assert
+    expect(lunar.day, exampleDate.day);
+    expect(lunar.month, exampleDate.month);
+    expect(lunar.year, exampleDate.year);
+  });
+
+  test('initialize Lunar with createdFromSolar = true', () {
+    // Arrange
+    DateTime exampleDate = DateTime(1999, 6, 18);
+    DateTime lunarExampleDate = DateTime(1999, 5, 5);
+
+    // Act
+    Lunar lunar = Lunar(
+      createdFromSolar: true,
+      date: exampleDate,
+    );
+    Lunar lunarExample = Lunar(
+      createdFromSolar: false,
+      date: lunarExampleDate,
+    );
+
+    // Assert
+    expect(lunar, lunarExample);
+    expect(lunar, lunarExample);
+    expect(lunar, lunarExample);
   });
 }

--- a/test/vnlunar_test.dart
+++ b/test/vnlunar_test.dart
@@ -72,11 +72,10 @@ void main() {
     int dd = 2;
     int mm = 2;
     int yy = 2023;
-    int leap = 0;
     int timeZone = 7;
 
     // Act
-    List<int> solar = convertLunar2Solar(dd, mm, yy, leap, timeZone);
+    List<int> solar = convertLunar2Solar(dd, mm, yy, false, timeZone);
 
     // Assert
     expect(solar, [21, 2, 2023]);
@@ -87,11 +86,10 @@ void main() {
     int dd = 2;
     int mm = 2;
     int yy = 2023;
-    int leap = 1;
     int timeZone = 7;
 
     // Act
-    List<int> solar = convertLunar2Solar(dd, mm, yy, leap, timeZone);
+    List<int> solar = convertLunar2Solar(dd, mm, yy, true, timeZone);
 
     // Assert
     expect(solar, [23, 3, 2023]);


### PR DESCRIPTION
- Add Solar, Lunar classes
- Use bool instead of int for lunarLeap
- Set default timezone to 7 (GMT+7)
- Fix a bug in jdToDate function that sometimes leads to wrong calculation