### PR TITLE
Refactor Lunar and Solar

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Thanks to him for inspiring me to create this package in Dart.
 
 - From version 1.1.0, the package supports Classes instead of Lists for easier access. `Lunar` and `Solar` provide methods to interact with each other, or converted to DateTime object.
 ```dart
-  final lunar = Lunar(createdFromSolar: true, date: DateTime(1998, 6, 18));
-  final solar = Solar(DateTime(1998, 6, 18));
+  final solar = Solar(1998, 6, 18);
+  final lunar = Lunar.createFromSolar(solar);
   final convertedSolarFromLunar = lunar.getSolar();
   
   // solar == convertedSolarFromLunar -> true

--- a/lib/src/lunar.dart
+++ b/lib/src/lunar.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_unused_constructor_parameters
-
 import 'package:vnlunar/src/constants.dart';
 import 'package:vnlunar/src/solar.dart';
 import 'package:vnlunar/src/vnlunar_base.dart';

--- a/lib/src/lunar.dart
+++ b/lib/src/lunar.dart
@@ -1,104 +1,85 @@
-// ignore_for_file: unnecessary_overrides
+// ignore_for_file: avoid_unused_constructor_parameters
 
 import 'package:vnlunar/src/constants.dart';
+import 'package:vnlunar/src/solar.dart';
+import 'package:vnlunar/src/vnlunar_base.dart';
 
-import 'solar.dart';
-import 'vnlunar_base.dart';
+final class Lunar {
+  late final DateTime _rawDateTime;
+  DateTime get dateTime => _rawDateTime;
 
-class Lunar extends VNLunar implements Comparable<Lunar> {
-  late final int _year;
-  int get year => _year;
+  late final bool _leapMonth;
+  bool get leapMonth => _leapMonth;
 
-  late final int _month;
-  int get month => _month;
+  int get day => _rawDateTime.day;
+  int get month => _rawDateTime.month;
+  int get year => _rawDateTime.year;
 
-  late final int _day;
-  int get day => _day;
+  Lunar(int year, int month, int day) {
+    bool isYearValid = year >= 0;
+    bool isMonthValid = month >= 1 && month <= 12;
+    bool isDayValid = day >= 0 && day <= _getNumberOfDays(month, year);
+    assert(!isYearValid || !isMonthValid || !isDayValid, "Date is not valid");
 
-  late final int _hour;
-  int get hour => _hour;
+    // TODO (htrang) : implement isLeapMonth(year, month, day) or only visible for
+    // testing since leapMonth information is inconsistence
 
-  late final int _minute;
-  int get minute => _minute;
+    _rawDateTime = DateTime(year, month, day);
+  }
 
-  late final int _second;
-  int get second => _second;
+  Lunar._(DateTime? date, [bool leapMonth = false]) {
+    _rawDateTime = date ?? DateTime.now().toLocal();
+    _leapMonth = leapMonth;
+  }
 
-  late final bool? _leapMonth;
-  bool? get leapMonth => _leapMonth;
+  static Lunar createFromSolar(DateTime? date) {
+    date = date ?? DateTime.now().toLocal();
 
-  /// Create an instance of [Lunar] from [date]. If [date] is null,
-  /// automatically constructs a [Lunar] with current date and time
-  /// in the local time zone.
-  Lunar({
-    DateTime? date,
-    required bool createdFromSolar,
-  }) : this._fromDate(
-          date ?? DateTime.now().toLocal(),
-          createdFromSolar,
-        );
+    final rawLunar = convertSolar2Lunar(date.day, date.month, date.year);
+    return Lunar._(
+        DateTime(rawLunar[yearIndex], rawLunar[monthIndex], rawLunar[dayIndex],
+            date.hour, date.minute, date.second),
+        rawLunar.last == 1);
+  }
+}
 
-  /// Create an instance of [Lunar] from [Solar].
-  Lunar.fromSolar(Solar solar)
-      : this(
-          date: solar.toDateTime(),
-          createdFromSolar: true,
-        );
-
-  /// Convert to Solar. leapMonth = false if not specified.
+extension SolarConvertible on Lunar {
   Solar getSolar() {
-    final solar = convertLunar2Solar(_day, _month, _year, _leapMonth ?? false);
-    return Solar(DateTime(
-      solar[yearIndex],
-      solar[monthIndex],
-      solar[dayIndex],
-    ));
+    final rawSolar = convertLunar2Solar(
+        _rawDateTime.day, _rawDateTime.month, _rawDateTime.year, leapMonth);
+    return Solar(rawSolar[yearIndex], rawSolar[monthIndex], rawSolar[dayIndex]);
   }
+}
 
-  Lunar._fromDate(DateTime dateTime, bool createdFromSolar) {
-    if (!createdFromSolar) {
-      _year = dateTime.year;
-      _month = dateTime.month;
-      _day = dateTime.day;
-      _hour = dateTime.hour;
-      _minute = dateTime.minute;
-      _second = dateTime.second;
-      return;
-    }
-
-    final lunar =
-        convertSolar2Lunar(dateTime.day, dateTime.month, dateTime.year);
-    _year = lunar[yearIndex];
-    _month = lunar[monthIndex];
-    _day = lunar[dayIndex];
-    _leapMonth = (lunar.last == 1);
-    _hour = dateTime.hour;
-    _minute = dateTime.minute;
-    _second = dateTime.second;
+int _getNumberOfDays(int month, int year) {
+  bool isYearValid = year >= 0;
+  bool isMonthValid = month >= 1 && month <= 12;
+  if (!isYearValid || !isMonthValid) return 0;
+  switch (month) {
+    case 1:
+      return 31;
+    case 2:
+      return year % 4 == 0 && year % 100 == 0 ? 29 : 28;
+    case 3:
+      return 31;
+    case 4:
+      return 30;
+    case 5:
+      return 31;
+    case 6:
+      return 30;
+    case 7:
+      return 31;
+    case 8:
+      return 31;
+    case 9:
+      return 30;
+    case 10:
+      return 31;
+    case 11:
+      return 30;
+    case 12:
+      return 31;
   }
-
-  @override
-  int compareTo(Lunar other) {
-    if (this == other) return 0;
-    return getSolar().compareTo(other.getSolar());
-  }
-
-  @override
-  bool operator ==(other) {
-    return other is Lunar &&
-        other.year == _year &&
-        other.month == _month &&
-        other.day == _day &&
-        other.hour == _hour &&
-        other.minute == _minute &&
-        other.second == _second;
-  }
-
-  @override
-  int get hashCode => super.hashCode;
-
-  @override
-  DateTime toDateTime() {
-    return DateTime(_year, _month, _day, _hour, _minute, _second);
-  }
+  return 0;
 }

--- a/lib/src/solar.dart
+++ b/lib/src/solar.dart
@@ -1,73 +1,7 @@
 // ignore_for_file: unnecessary_overrides
 
 import 'lunar.dart';
-import 'vnlunar_base.dart';
 
 /// An instant in time, similar to [DateTime] object, having functions
-/// that helps interacting with [Lunar] much more easier.
-class Solar extends VNLunar implements Comparable<Solar> {
-  late final int _year;
-  int get year => _year;
-
-  late final int _month;
-  int get month => _month;
-
-  late final int _day;
-  int get day => _day;
-
-  late final int _hour;
-  int get hour => _hour;
-
-  late final int _minute;
-  int get minute => _minute;
-
-  late final int _second;
-  int get second => _second;
-
-  /// Create an instance of [Solar] from [dateTime]. If [dateTime] is null,
-  /// automatically constructs a [Solar] with current date and time
-  /// in the local time zone.
-  Solar([DateTime? dateTime])
-      : this._fromDate(dateTime ?? DateTime.now().toLocal());
-
-  Solar._fromDate(DateTime dateTime) {
-    _year = dateTime.year;
-    _month = dateTime.month;
-    _day = dateTime.day;
-    _hour = dateTime.hour;
-    _minute = dateTime.minute;
-    _second = dateTime.second;
-  }
-
-  @override
-  DateTime toDateTime() {
-    return DateTime(
-      _year,
-      _month,
-      _day,
-      _hour,
-      _minute,
-      _second,
-    );
-  }
-
-  @override
-  int compareTo(Solar other) {
-    if (this == other) return 0;
-    return toDateTime().compareTo(other.toDateTime());
-  }
-
-  @override
-  bool operator ==(other) {
-    return other is Solar &&
-        other.year == _year &&
-        other.month == _month &&
-        other.day == _day &&
-        other.hour == _hour &&
-        other.minute == _minute &&
-        other.second == _second;
-  }
-
-  @override
-  int get hashCode => super.hashCode;
-}
+/// that helps interacting with [Lunar] much easier.
+typedef Solar = DateTime;

--- a/lib/src/solar.dart
+++ b/lib/src/solar.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: unnecessary_overrides
-
 import 'lunar.dart';
 
 /// An instant in time, similar to [DateTime] object, having functions

--- a/lib/src/vnlunar_base.dart
+++ b/lib/src/vnlunar_base.dart
@@ -5,13 +5,6 @@ import 'constants.dart';
 const double _juliusDaysIn1900 = 2415021.076998695;
 const double _newMoonCycle = 29.530588853;
 
-abstract class VNLunar {
-  /// Returns DateTime format. If the current object is using Lunar system,
-  /// returns its properties with DateTime format. [Lunar] can use `toSolar` then
-  /// `toDateTime`, which is the same.
-  DateTime toDateTime();
-}
-
 /// Compute the (integral) Julian day number of day dd/mm/yyyy, i.e., the number
 /// of days between 1/1/4713 BC (Julian calendar) and dd/mm/yyyy.
 /// Formula from http://www.tondering.dk/claus/calendar.html

--- a/test/vnlunar_test.dart
+++ b/test/vnlunar_test.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:test/test.dart';
 import 'package:vnlunar/vnlunar.dart';
 
@@ -97,9 +99,8 @@ void main() {
 
   test('compare Solar with lunar.getSolar', () {
     // Arrange
-    DateTime exampleDate = DateTime(1999, 6, 18);
-    Lunar lunar = Lunar(createdFromSolar: true, date: exampleDate);
-    Solar solar = Solar(exampleDate);
+    Solar solar = Solar(1999, 6, 18);
+    Lunar lunar = Lunar.createFromSolar(solar);
     Solar convertedSolarFromLunar = lunar.getSolar();
 
     // Act
@@ -107,53 +108,5 @@ void main() {
 
     // Assert
     expect(compare, true);
-  });
-
-  test('compare Solar with lunar.getSolar', () {
-    // Arrange
-    DateTime exampleDate = DateTime(1999, 6, 19);
-    Lunar lunar = Lunar(createdFromSolar: true, date: exampleDate);
-    Solar solar = Solar(DateTime(1999, 6, 18));
-    Solar convertedSolarFromLunar = lunar.getSolar();
-
-    // Act
-    bool compare = convertedSolarFromLunar == solar;
-
-    // Assert
-    expect(compare, false);
-  });
-
-  test('initialize Lunar with createdFromSolar = false', () {
-    // Arrange
-    DateTime exampleDate = DateTime(1999, 6, 18);
-
-    // Act
-    Lunar lunar = Lunar(createdFromSolar: false, date: exampleDate);
-
-    // Assert
-    expect(lunar.day, exampleDate.day);
-    expect(lunar.month, exampleDate.month);
-    expect(lunar.year, exampleDate.year);
-  });
-
-  test('initialize Lunar with createdFromSolar = true', () {
-    // Arrange
-    DateTime exampleDate = DateTime(1999, 6, 18);
-    DateTime lunarExampleDate = DateTime(1999, 5, 5);
-
-    // Act
-    Lunar lunar = Lunar(
-      createdFromSolar: true,
-      date: exampleDate,
-    );
-    Lunar lunarExample = Lunar(
-      createdFromSolar: false,
-      date: lunarExampleDate,
-    );
-
-    // Assert
-    expect(lunar, lunarExample);
-    expect(lunar, lunarExample);
-    expect(lunar, lunarExample);
   });
 }


### PR DESCRIPTION
As the subject's described. This PR consists mainly on refactoring + cleaning stuffs around Lunar and Solar.

I remarked some inconsistent stuffs : It's not user's responsibility to choose if the given raw date has a leap month or not, he/she should not set this variable. This should be disabled. If not, would there be possible to have `getIsLeapMonth(lunarYear, lunarMonth, lunarDay)` ?

Thanks,
Vu 