### PR TITLE
[Bugfix] _leapMonth LateInitializationError

### DIFF
--- a/lib/src/lunar.dart
+++ b/lib/src/lunar.dart
@@ -63,6 +63,7 @@ class Lunar extends VNLunar implements Comparable<Lunar> {
       _hour = dateTime.hour;
       _minute = dateTime.minute;
       _second = dateTime.second;
+      _leapMonth = null;
       return;
     }
 


### PR DESCRIPTION
### Error Log
```
Another exception was thrown: LateInitializationError: Field
'_leapMonth@415372003' has not been initialized.
```

I have fixed LateInitializationError issue. 
IMO, It would be okay to provide _leapMonth with a default value as false instead of boolean optional type.